### PR TITLE
Nicer visuals for the news and events in the sidebar.

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -9,10 +9,8 @@
     _[EOSC Symposium 2022](https://events.eoscfuture.eu/symposium2022/programme)_, Prague, CZ, 2022-11-14 / --17  
     <https://doi.org/10.5281/zenodo.7323471>
 - name: 1st International Conference on FAIR Digital Objects
-  startDate: 2023-10-26
-  endDate: 2023-10-28
-  location: > 
-    [hehe](hehe)
+  startDate: 2022-10-26
+  endDate: 2022-10-28
   description: The [1st International Conference on FAIR Digital Objects](https://www.fdo2022.org/) takes place between 26-28 October 2022. WorkflowHub features in several talks and posters highlighting how RO-Crate is a web-native and practical implementation of FDOs.
 - name: FAIR Computational Workflows workshop
   startDate: 2020-09-02

--- a/_data/events.yml
+++ b/_data/events.yml
@@ -9,8 +9,10 @@
     _[EOSC Symposium 2022](https://events.eoscfuture.eu/symposium2022/programme)_, Prague, CZ, 2022-11-14 / --17  
     <https://doi.org/10.5281/zenodo.7323471>
 - name: 1st International Conference on FAIR Digital Objects
-  startDate: 2022-10-26
-  endDate: 2022-10-28
+  startDate: 2023-10-26
+  endDate: 2023-10-28
+  location: > 
+    [hehe](hehe)
   description: The [1st International Conference on FAIR Digital Objects](https://www.fdo2022.org/) takes place between 26-28 October 2022. WorkflowHub features in several talks and posters highlighting how RO-Crate is a web-native and practical implementation of FDOs.
 - name: FAIR Computational Workflows workshop
   startDate: 2020-09-02

--- a/_includes/sidebar-events.html
+++ b/_includes/sidebar-events.html
@@ -1,0 +1,32 @@
+<div class="news-sidebar upcoming_events mt-5 rounded">
+  <h2 class="no-anchor">Events</h2>
+  <ul class="list-unstyled mb-0">
+      {%- assign events = site.data.events | reverse %}
+      {%- assign count = 0 %}
+      {%- for event in events %}
+      <li class='upcoming_event' data-start='{{ event.startDate}}'>
+          <div class="news-item news-hover">
+            <a class="stretched-link" data-bs-toggle="collapse" href="#collapse-events-{{count}}" role="button" aria-expanded="false" aria-controls="collapse-{{count}}"><span class="mb-1">{{ event.name | escape }}</span></a>
+            <p class="mb-0"><small><i class="far fa-calendar me-2"></i><time datetime="{{ event.startDate | date: '%e %B, %Y %H:%M' }}">{{ event.startDate | date_to_long_string }} {{event.startTime}}</time>
+            {% if event.endDate or event.endTime %} - <time datetime="{{ event.endDate | date: '%e %B, %Y %H:%M %Z' }}">{{ event.endDate | date_to_long_string }} {{event.endTime}}</time>{% endif %}</small></p>
+            {%- if event.location %}
+            <i class="fa-solid fa-map-marker-alt me-2 small"></i><div class="clean-md d-inline-block small">{{ event.location | markdownify}}</div>
+            {%- endif %}
+            <div class="collapse clean-md small mt-2" id="collapse-events-{{count}}">
+              {{ event.description | markdownify }}
+            </div>
+          </div>
+      </li>
+      {%- assign count = count | plus: 1 %}
+      {%- endfor %}
+  </ul>
+  <div class="news-item">
+    <p><small>See the full list of events, including past events, on the <a href="{{'/project/events' | relative_url }}">events</a> page.</small></p>
+  </div>
+  <script>
+    $(document).ready(function() {
+      show_upcoming_events()
+    });
+  </script>
+</div>
+

--- a/_includes/sidebar-news.html
+++ b/_includes/sidebar-news.html
@@ -1,0 +1,27 @@
+{%- if site.data.news.size > 0 -%}
+<div class="news-sidebar mb-5 rounded">
+    <h2 class="no-anchor">News</h2>
+    <ul class="list-unstyled mb-0">
+    {%- assign news = site.data.news | sort: "date" %}
+    {%- assign count = 0 %}
+    {%- for post in news reversed%}
+        <li>
+            <div class="news-item news-hover">
+                <a class="stretched-link" data-bs-toggle="collapse" href="#collapse-news-{{count}}" role="button" aria-expanded="false" aria-controls="collapse-{{count}}"><span class="mb-1">{{ post.name | escape }}</span></a>
+                <br/><small>{{ post.date | date: site.date_format }}</small>
+                <div class="collapse clean-md small mt-2" id="collapse-news-{{count}}">
+                    {{ post.description | markdownify }}
+                </div>
+            </div>
+        </li>
+    {%- assign count = count | plus: 1 %}
+    {%- if include.limit and count == include.limit %}
+    {%- break %}
+    {%- endif %}
+    {%- endfor %}
+    </ul>
+    <div class="news-item">
+        <p><small>For more news please visit our <a href="{{'/project/news' | relative_url }}">news page</a></small></p>
+    </div>
+</div>
+{%- endif -%}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,12 +12,10 @@
                 {%- unless page.hide_sidebar %}
                 {% include sidebar.html %}
                 {%- else %}
-                <h3>News</h3>
-                {% include news.html limit=3 %}
-                <p><small>For more news please visit our <a href="{{'/project/news' | relative_url }}">news page</a>.</small></p>
-                <h3 class="mt-5">Events</h3>
-                {% include events.html event_type="upcoming_event" truncate=true %}
-                <p><small>See the full list of events, including past events, on the <a href="{{'/project/events' | relative_url }}">events</a> page.</small></p>
+                {%- if page.path == "index.md" %}
+                {% include sidebar-news.html %}
+                {% include sidebar-events.html %}
+                {%- endif %}
                 {%- endunless %}
             </div>
             <!-- Content Column -->

--- a/_sass/_custom_classes.scss
+++ b/_sass/_custom_classes.scss
@@ -40,6 +40,43 @@ header .navbar {
     margin: 10px 0px;
 }
 
+// News section front-page
+
+.news-sidebar {
+    background-color: $light;
+
+    .news-item {
+        padding: 7px 11px;
+        position: relative;
+        a:not(.stretched-link), button:not(.stretched-link) {
+            z-index: 2;
+            position: relative;
+        }
+        .clean-md {
+            p {
+                margin-bottom: 0;
+            }
+        }
+    }
+
+    .news-hover:hover {
+        text-decoration: none;
+        background-color: $primary;
+        color: $white;
+        a.stretched-link {
+            color: $white;
+        }
+    }
+
+    h2 {
+        font-size: 1.6em;
+        font-weight: 700;
+        color: $primary;
+        padding: 7px 11px;
+    }
+}
+
+
 /*-----Custom landing page-----*/
 
 @media (max-width: 992px) {


### PR DESCRIPTION
The current sidebar on the landing page is using elements that were originally not meant to be in the sidebar, which you can see visually. Based on the FAIRDOM website, I recreated the ones here, and made them collapsable. It should go a bit more easy on the eyes:

![Screenshot from 2023-02-02 17-13-46](https://user-images.githubusercontent.com/44875756/216380846-88575731-d4b4-493a-a147-d6ed49e9e03d.png)
![Screenshot from 2023-02-02 17-13-55](https://user-images.githubusercontent.com/44875756/216380841-0f0e8e26-b5a7-44f6-8350-8c2f264fbac2.png)
![Screenshot from 2023-02-02 17-14-48](https://user-images.githubusercontent.com/44875756/216380831-53a747f2-fb90-408a-bb33-ca64c70644e5.png)


