### PR TITLE
Updating collapsible buttons 

### DIFF
--- a/_data/sidebars/documentation.yml
+++ b/_data/sidebars/documentation.yml
@@ -1,8 +1,7 @@
 title: Documentation
 subitems:
   - title: Quick start guide
-    title_url: /docs/
-  - title: Getting started with WorkflowHub
+    title_url: /docs/index
     subitems:
     - title: How to register
       url: /docs/how-to-register/

--- a/_sass/_custom_classes.scss
+++ b/_sass/_custom_classes.scss
@@ -87,3 +87,16 @@ header .navbar {
         order: 1;
     }
 }
+
+
+/*-----buttons that collapse-----*/
+
+.btn-collapse {
+    overflow-wrap: anywhere;
+    padding: 5px 5px 5px;
+    margin: 8px;
+    border-radius: 4px;
+    border: outset;
+    background-color: $primary;
+    color: white;
+}

--- a/docs/join-create-teams-spaces.md
+++ b/docs/join-create-teams-spaces.md
@@ -21,7 +21,7 @@ You can join one or more existing Teams by:
 
 
 <p>
-  <a class="btn-collapse" data-toggle="collapse" href="#collapse1" role="button" aria-expanded="false" aria-controls="collapse1">
+  <a class="btn-collapse" data-toggle="collapse" href="#join-team-registration" role="button" aria-expanded="false" aria-controls="collapse1">
     Joining an existing Team immediately after registration
   </a>
 </p>
@@ -38,12 +38,12 @@ Once the Team(s) are selected, the process is the same as requesting membership 
 
 
 <p>
-  <a class="btn-collapse" data-toggle="collapse" href="#collapse1" role="button" aria-expanded="false" aria-controls="collapse1">
+  <a class="btn-collapse" data-toggle="collapse" href="#request-to-join-team" role="button" aria-expanded="false" aria-controls="collapse2">
     Requesting membership of an existing Team
   </a>
 </p>
 
-<div class="collapse" id="collapse1">
+<div class="collapse" id="collapse2">
 <div class="card card-body">
 
 If a Team has an administrator, and you are not already a member - then a `request membership` button will appear on the Team page. You can browse, filter and search Teams from the Browse menu at the top of the page.


### PR DESCRIPTION
Collapsible buttons on `join-create-teams-spaces.md` page are not working. 
Suggesting changes to `scss` and page content to address this.

Also updated nav structure for the quick start guide link, so that it points to `docs/index.md`