### PR TITLE
Add missing redirect for workflow registration page

### DIFF
--- a/docs/registering_workflows/registering-a-workflow.md
+++ b/docs/registering_workflows/registering-a-workflow.md
@@ -1,6 +1,7 @@
 ---
 title: Registering a workflow on WorkflowHub
 redirect_from: 
+  - /registering-a-workflow/
   - /registering-workflows/
   - /Registering-an-existing-Workflow-RO-Crate/
   - /How-to-register-your-workflow(s)-in-WorkflowHub/


### PR DESCRIPTION
I found the old link (https://about.workflowhub.eu/docs/registering-a-workflow/) in a [GTN tutorial page](https://gallantries.github.io/video-library/videos/ro-crates/workflowhub/tutorial/) (which I will also put in a PR to update)