### PR TITLE
Update links/redirects to registering a workflow page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -60,6 +60,6 @@ More information on how to join a team can be found on the [how to create and jo
 
 Workflows can be registered using the [WorkflowHub wizard](https://workflowhub.eu/workflows/new)
 
-There is an extensive guide to the [workflow registration process](/docs/registering-a-workflow/) available in the WorkflowHub documentation.
+There is an extensive guide to the [workflow registration process](/docs/registering_workflows/registering-a-workflow/) available in the WorkflowHub documentation.
 
 {% include callout.html type="important" content="We recommend importing a git repository (e.g. GitHub), since WorkflowHub is a hub / registry and not a repository." %}

--- a/docs/registering_workflows/registering-a-workflow.md
+++ b/docs/registering_workflows/registering-a-workflow.md
@@ -1,7 +1,7 @@
 ---
 title: Registering a workflow on WorkflowHub
 redirect_from: 
-  - /registering-a-workflow/
+  - /docs/registering-a-workflow/
   - /registering-workflows/
   - /Registering-an-existing-Workflow-RO-Crate/
   - /How-to-register-your-workflow(s)-in-WorkflowHub/


### PR DESCRIPTION
My earlier PR #60 doesn't seem to have fixed the redirect as intended, and I found the old link in another location in the docs. I think this should fix both issues.