### PR TITLE
Update adding-files.md

### DIFF
--- a/docs/registering_workflows/adding-files.md
+++ b/docs/registering_workflows/adding-files.md
@@ -15,7 +15,7 @@ Once you have either clicked on the `Contribute` button, or selected `Workflow` 
 ## Upload / import a local file {#local}
 
 1. Select your local workflow file using the `Browse…` button
-2. Pick your [workflow type](/docs/supported-workflow-types) - if your workflow type is not included in the list you can select `Other` or add a `New workflow type` using the available button.
+2. Pick your [workflow type](/docs/registering_workflows/supported-workflow-types) - if your workflow type is not included in the list you can select `Other` or add a `New workflow type` using the available button.
 3. Optional: add in a [Abstract CWL](/docs/glossary#abstract-cwl) using the `Browse…` button
 4. Optional: add in a [Diagram file](/docs/glossary#diagram) using the `Browse…` button
 5. Click the `Register` button


### PR DESCRIPTION
There is a missing directory in the path for the docs: https://about.workflowhub.eu/docs/registering_workflows/adding-files/  It links to workflow types, but misses the registering-workflows from the path. Links to:
https://about.workflowhub.eu/docs/supported-workflow-types

but should be:

https://about.workflowhub.eu/docs/registering_workflows/supported-workflow-types/