### PR TITLE
Use ComputationalWorkflow instead of HowTo in the example

### DIFF
--- a/Workflow-RO-Crate/0.2/example/ro-crate-metadata.json
+++ b/Workflow-RO-Crate/0.2/example/ro-crate-metadata.json
@@ -55,7 +55,7 @@
       "@type": [
         "File",
         "SoftwareSourceCode",
-        "HowTo"
+        "ComputationalWorkflow"
       ],
       "programmingLanguage": {
         "@id": "#cwl"

--- a/Workflow-RO-Crate/0.2/example/ro-crate-preview.html
+++ b/Workflow-RO-Crate/0.2/example/ro-crate-preview.html
@@ -101,7 +101,7 @@
       "@type": [
         "File",
         "SoftwareSourceCode",
-        "HowTo"
+        "ComputationalWorkflow"
       ],
       "programmingLanguage": {
         "@id": "#cwl"
@@ -292,7 +292,7 @@ table.table {
                         
                         <li><span>SoftwareSourceCode</span></li>
                         
-                        <li><span>HowTo</span></li>
+                        <li><span>ComputationalWorkflow</span></li>
                         </ul></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">programmingLanguage<span>&nbsp;</span><a href="http://schema.org/programmingLanguage">[?]</a></th>

--- a/Workflow-RO-Crate/0.2/index.md
+++ b/Workflow-RO-Crate/0.2/index.md
@@ -321,7 +321,7 @@ A minimal example of _Workflow RO-Crate_ metadata, containing a CWL workflow, an
       "@type": [
         "File",
         "SoftwareSourceCode",
-        "HowTo"
+        "ComputationalWorkflow"
       ],
       "programmingLanguage": {
         "@id": "#cwl"

--- a/Workflow-RO-Crate/1.0/index.md
+++ b/Workflow-RO-Crate/1.0/index.md
@@ -365,7 +365,7 @@ A minimal example of _Workflow RO-Crate_ metadata, containing a CWL workflow, an
       "@type": [
         "File",
         "SoftwareSourceCode",
-        "HowTo"
+        "ComputationalWorkflow"
       ],
       "programmingLanguage": {
         "@id": "https://w3id.org/workflowhub/workflow-ro-crate#cwl"


### PR DESCRIPTION
as reported in #75 

if it is intended to be an abstract descriptive workflow, and HowTo is correct, then maybe need another example