### PR TITLE
exclude the 0.2 ro-crate spec from search results

### DIFF
--- a/Workflow-RO-Crate/0.2/index.md
+++ b/Workflow-RO-Crate/0.2/index.md
@@ -1,4 +1,6 @@
-# Workflow RO-Crate (DRAFT)
+---
+title: Workflow RO-Crate profile 0.2 (Draft)
+---
 
 <!--  https://signposting.org/FAIR/  markup --->
 

--- a/_config.yml
+++ b/_config.yml
@@ -34,6 +34,10 @@ defaults:
       type: "pages"
     values:
       sidebar: documentation
+  - scope:
+      path: "Workflow-RO-Crate/0.2"
+    values:
+      search_exclude: true
 
 theme_variables: 
   theme_color: 1f8787


### PR DESCRIPTION
Exclude search for the 0.2 ro crate pages.
Also fixed the title on the 0.2 spec page ( was appearing double - https://about.workflowhub.eu/Workflow-RO-Crate/0.2/ ).