### PR TITLE
Add profile keywords; constrain compatibility to RO-Crate 1.2 only; add backward compatibility notes

### DIFF
--- a/Workflow-RO-Crate/1.1-DRAFT/changelog.md
+++ b/Workflow-RO-Crate/1.1-DRAFT/changelog.md
@@ -2,4 +2,8 @@
 
 ## 1.1.0
 
-* Profile conformance should now be declared on the root data entity (inherited from [RO-Crate 1.2](https://www.researchobject.org/ro-crate/specification/1.2/root-data-entity.html#ro-crate-metadata-descriptor))
+* Updated examples and Profile Crate to align with RO-Crate 1.2 ([#83](https://github.com/workflowhub-eu/about/pull/83/files)) ([#86](https://github.com/workflowhub-eu/about/pull/86))
+* Profile conformance should now be declared on the root data entity (inherited from [RO-Crate 1.2](https://www.researchobject.org/ro-crate/specification/1.2/root-data-entity.html#ro-crate-metadata-descriptor)) ([#83](https://github.com/workflowhub-eu/about/pull/83/files))
+* Clarified that additional types may be included for the main workflow ([#87](https://github.com/workflowhub-eu/about/pull/87))
+* Added guidance for describing workflow parameters & steps (aligned with the [Workflow Run Crate profile](https://www.researchobject.org/workflow-run-crate/profiles/workflow_run_crate/)) ([#87](https://github.com/workflowhub-eu/about/pull/87))
+    * This addition means that the profile is no longer backward compatible with RO-Crate 1.1, because the IRI mappings for the properties `input` and `output` were updated in the [RO-Crate 1.2 JSON-LD context](https://www.researchobject.org/ro-crate/specification/1.2/context.jsonld).

--- a/Workflow-RO-Crate/1.1-DRAFT/index.md
+++ b/Workflow-RO-Crate/1.1-DRAFT/index.md
@@ -35,6 +35,7 @@ title: Workflow RO-Crate profile 1.1-DRAFT
 <link href="http://schema.org/HowTo" rel="item" />
 <link href="http://schema.org/ImageObject" rel="item" />
 <link href="https://github.com/KockataEPich/CheckMyCrate/blob/master/CheckMyCrate/profile_library/ro_crate_1.1_basic.json" rel="item" />
+<link href="https://github.com/crs4/rocrate-validator/tree/develop/rocrate_validator/profiles/workflow-ro-crate/" rel="item" />
 
 ![Workflow RO-Crate]({{ '/assets/img/ro-crate-workflow.svg' | relative_url }}){: height="300px" width="300px"}
 
@@ -74,13 +75,12 @@ This section uses terminology from the [RO-Crate 1.2 specification](https://w3id
 
 ### Context
 
-The _Crate_ JSON-LD MUST be valid according to [RO-Crate 1.1](https://w3id.org/ro/crate/1.1) or later minor version, and SHOULD use the corresponding version of the RO-Crate `@context` - such as <https://w3id.org/ro/crate/1.1/context> for RO-Crate 1.1.
+The _Crate_ JSON-LD MUST be valid according to [RO-Crate 1.2](https://w3id.org/ro/crate/1.2) or later minor version, and SHOULD use the corresponding version of the RO-Crate `@context` - such as <https://w3id.org/ro/crate/1.2/context> for RO-Crate 1.2.
 
 ### Declaring Profile Conformance
 
 The [Root Data Entity](https://www.researchobject.org/ro-crate/specification/1.2/root-data-entity.html#direct-properties-of-the-root-data-entity) `conformsTo` SHOULD be an array that contains at least <https://w3id.org/workflowhub/workflow-ro-crate/1.1>.
 
-For historical reasons, in Workflow RO-Crates conforming to RO-Crate version 1.1, <https://w3id.org/workflowhub/workflow-ro-crate/1.1> MAY instead be included in `conformsTo` on the [Metadata File Descriptor](https://www.researchobject.org/ro-crate/specification/1.2/root-data-entity.html#ro-crate-metadata-file-descriptor).  
 
 
 ### Main Workflow
@@ -408,3 +408,13 @@ A minimal example of _Workflow RO-Crate_ metadata, containing a CWL workflow, an
   ]
 }
 ```
+
+## Backward compatibility
+
+This section is aimed at implementers of Workflow RO-Crate who wish to support both current and previous versions of the profile.
+
+In RO-Crates conforming to Workflow RO-Crate 1.0 and RO-Crate 1.1, <https://w3id.org/workflowhub/workflow-ro-crate/1.1> MAY be included in `conformsTo` on the [Metadata File Descriptor](https://www.researchobject.org/ro-crate/specification/1.2/root-data-entity.html#ro-crate-metadata-file-descriptor) rather than the Root Data Entity.
+
+Note that the IRI mappings for the `input` and `output` properties were updated in the [RO-Crate 1.2 JSON-LD context](https://www.researchobject.org/ro-crate/specification/1.2/context.jsonld). These properties were not mentioned in version 1.0 of this profile, but some conforming crates and implementations may use them, as they are referenced in both the [RO-Crate specification](https://www.researchobject.org/ro-crate/specification/1.2/workflows.html#describing-inputs-and-outputs) and the [Workflow Run Crate profile](https://www.researchobject.org/workflow-run-crate/profiles/workflow_run_crate/). Implementers should therefore be aware of the previous IRIs when reading older crates.
+    * `input` changed from `https://bioschemas.org/ComputationalWorkflow#input` to `https://bioschemas.org/properties/input` .
+    * `output` changed from `https://bioschemas.org/ComputationalWorkflow#output` to `https://bioschemas.org/properties/output`.

--- a/Workflow-RO-Crate/1.1-DRAFT/ro-crate-metadata.json
+++ b/Workflow-RO-Crate/1.1-DRAFT/ro-crate-metadata.json
@@ -69,6 +69,12 @@
         },
         {
           "@id": "example/"
+        },
+        {
+          "@id": "https://github.com/KockataEPich/CheckMyCrate/blob/master/CheckMyCrate/profile_library/ro_crate_1.1_basic.json"
+        },
+        {
+          "@id": "https://github.com/crs4/rocrate-validator/tree/develop/rocrate_validator/profiles/workflow-ro-crate/"
         }
       ],
       "mentions": [

--- a/Workflow-RO-Crate/1.1-DRAFT/ro-crate-metadata.json
+++ b/Workflow-RO-Crate/1.1-DRAFT/ro-crate-metadata.json
@@ -39,6 +39,9 @@
       ],
       "datePublished": "2023-03-13T10:43:00Z",
       "description": "This is the Profile Crate for Workflow RO-Crate. Workflow RO-Crates are a specialization of RO-Crate for packaging an executable workflow with all necessary documentation. It is aligned with, and intends to strictly extend, the more general Bioschemas ComputationalWorkflow profile.\n\nWorkflowHub uses Workflow RO-Crates as an exchange format for users to upload a packaged workflow.",
+      "keywords": [
+        "workflow"
+      ],
       "hasPart": [
         {
           "@id": "index.html"

--- a/Workflow-RO-Crate/1.1-DRAFT/ro-crate-preview.html
+++ b/Workflow-RO-Crate/1.1-DRAFT/ro-crate-preview.html
@@ -82,6 +82,12 @@
         },
         {
           "@id": "example/"
+        },
+        {
+          "@id": "https://github.com/KockataEPich/CheckMyCrate/blob/master/CheckMyCrate/profile_library/ro_crate_1.1_basic.json"
+        },
+        {
+          "@id": "https://github.com/crs4/rocrate-validator/tree/develop/rocrate_validator/profiles/workflow-ro-crate/"
         }
       ],
       "mentions": [
@@ -519,6 +525,22 @@
       ]
     },
     {
+      "@id": "https://github.com/KockataEPich/CheckMyCrate/blob/master/CheckMyCrate/profile_library/ro_crate_1.1_basic.json",
+      "@type": "File",
+      "encodingFormat": [
+        "application/json",
+        {
+          "@id": "https://github.com/KockataEPich/CheckMyCrate#profiles"
+        }
+      ],
+      "name": "CheckMyCrate profile for Workflow RO-Crate"
+    },
+    {
+      "@id": "https://github.com/crs4/rocrate-validator/tree/develop/rocrate_validator/profiles/workflow-ro-crate/",
+      "@type": "Dataset",
+      "name": "rocrate-validator profile for Workflow RO-Crate 1.0"
+    },
+    {
       "@id": "https://workflowhub.eu/",
       "@type": "RepositoryCollection",
       "description": "WorkflowHub is a registry for describing, sharing and publishing scientific computational workflows.",
@@ -544,22 +566,6 @@
       "name": "WfExS-backend",
       "url": "https://github.com/inab/WfExS-backend/",
       "version": "0.4.2"
-    },
-    {
-      "@id": "https://github.com/KockataEPich/CheckMyCrate/blob/master/CheckMyCrate/profile_library/ro_crate_1.1_basic.json",
-      "@type": "File",
-      "encodingFormat": [
-        "application/json",
-        {
-          "@id": "https://github.com/KockataEPich/CheckMyCrate#profiles"
-        }
-      ],
-      "name": "CheckMyCrate profile for Workflow RO-Crate"
-    },
-    {
-      "@id": "https://github.com/crs4/rocrate-validator/tree/develop/rocrate_validator/profiles/workflow-ro-crate/",
-      "@type": "Dataset",
-      "name": "rocrate-validator profile for Workflow RO-Crate 1.0"
     },
     {
       "@id": "https://spdx.org/licenses/BSD-3-Clause",
@@ -1544,6 +1550,10 @@ WorkflowHub uses Workflow RO-Crates as an exchange format for users to upload a 
                         <li><a href="#languages/">languages</a></li>
                         
                         <li><a href="#example/">Example RO-Crate following this profile</a></li>
+                        
+                        <li><a href="#https%3A//github.com/KockataEPich/CheckMyCrate/blob/master/CheckMyCrate/profile_library/ro_crate_1.1_basic.json">CheckMyCrate profile for Workflow RO-Crate</a></li>
+                        
+                        <li><a href="#https%3A//github.com/crs4/rocrate-validator/tree/develop/rocrate_validator/profiles/workflow-ro-crate/">rocrate-validator profile for Workflow RO-Crate 1.0</a></li>
                         </ul></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">mentions<span>&nbsp;</span><a href="http://schema.org/mentions">[?]</a></th>
@@ -2243,6 +2253,71 @@ WorkflowHub uses Workflow RO-Crates as an exchange format for users to upload a 
             </div>
         <hr/><br/><br/>
             <div>
+                <h3><a href="https://github.com/KockataEPich/CheckMyCrate/blob/master/CheckMyCrate/profile_library/ro_crate_1.1_basic.json">Go to: </a> CheckMyCrate profile for Workflow RO-Crate</h3>
+                
+                
+                
+                
+        <div id="https://github.com/KockataEPich/CheckMyCrate/blob/master/CheckMyCrate/profile_library/ro_crate_1.1_basic.json">
+            
+            <table class="table metadata table-striped" >
+                <tbody><tr>
+            <th style="text-align:left;" class="prop">@id</th>
+            <td style='text-align:left'><a href="https://github.com/KockataEPich/CheckMyCrate/blob/master/CheckMyCrate/profile_library/ro_crate_1.1_basic.json">https://github.com/KockataEPich/CheckMyCrate/blob/master/CheckMyCrate/profile_library/ro_crate_1.1_basic.json</a></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
+            <td style='text-align:left'><span>CheckMyCrate profile for Workflow RO-Crate</span></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">@type</th>
+            <td style='text-align:left'><span>File</span></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">encodingFormat<span>&nbsp;</span><a href="http://schema.org/encodingFormat">[?]</a></th>
+            <td style='text-align:left'><ul>
+                        <li><span>application/json</span></li>
+                        
+                        <li><a href="#https%3A//github.com/KockataEPich/CheckMyCrate%23profiles">CheckMyCrate</a></li>
+                        </ul></td>
+            </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
+            <td style='text-align:left'><a href="#./">Workflow RO-Crate profile</a></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">mentions<span>&nbsp;</span><a href="http://schema.org/mentions">[?]</a></th>
+            <td style='text-align:left'><a href="#./">Workflow RO-Crate profile</a></td>
+            </tr></tbody>
+            </table>
+        </div>
+            </div>
+        <hr/><br/><br/>
+            <div>
+                <h3><a href="https://github.com/crs4/rocrate-validator/tree/develop/rocrate_validator/profiles/workflow-ro-crate/">Go to: </a> rocrate-validator profile for Workflow RO-Crate 1.0</h3>
+                
+                
+                
+                
+        <div id="https://github.com/crs4/rocrate-validator/tree/develop/rocrate_validator/profiles/workflow-ro-crate/">
+            
+            <table class="table metadata table-striped" >
+                <tbody><tr>
+            <th style="text-align:left;" class="prop">@id</th>
+            <td style='text-align:left'><a href="https://github.com/crs4/rocrate-validator/tree/develop/rocrate_validator/profiles/workflow-ro-crate/">https://github.com/crs4/rocrate-validator/tree/develop/rocrate_validator/profiles/workflow-ro-crate/</a></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
+            <td style='text-align:left'><span>rocrate-validator profile for Workflow RO-Crate 1.0</span></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">@type</th>
+            <td style='text-align:left'><span>Dataset</span></td>
+            </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
+            <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
+            <td style='text-align:left'><a href="#./">Workflow RO-Crate profile</a></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">mentions<span>&nbsp;</span><a href="http://schema.org/mentions">[?]</a></th>
+            <td style='text-align:left'><a href="#./">Workflow RO-Crate profile</a></td>
+            </tr></tbody>
+            </table>
+        </div>
+            </div>
+        <hr/><br/><br/>
+            <div>
                 <h3><a href="https://workflowhub.eu/">Go to: </a> WorkflowHub</h3>
                 
                 
@@ -2342,65 +2417,6 @@ WorkflowHub uses Workflow RO-Crates as an exchange format for users to upload a 
             </tr><tr>
             <th style="text-align:left;" class="prop">version<span>&nbsp;</span><a href="http://schema.org/version">[?]</a></th>
             <td style='text-align:left'><span>0.4.2</span></td>
-            </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">mentions<span>&nbsp;</span><a href="http://schema.org/mentions">[?]</a></th>
-            <td style='text-align:left'><a href="#./">Workflow RO-Crate profile</a></td>
-            </tr></tbody>
-            </table>
-        </div>
-            </div>
-        <hr/><br/><br/>
-            <div>
-                <h3><a href="https://github.com/KockataEPich/CheckMyCrate/blob/master/CheckMyCrate/profile_library/ro_crate_1.1_basic.json">Go to: </a> CheckMyCrate profile for Workflow RO-Crate</h3>
-                
-                
-                
-                
-        <div id="https://github.com/KockataEPich/CheckMyCrate/blob/master/CheckMyCrate/profile_library/ro_crate_1.1_basic.json">
-            
-            <table class="table metadata table-striped" >
-                <tbody><tr>
-            <th style="text-align:left;" class="prop">@id</th>
-            <td style='text-align:left'><a href="https://github.com/KockataEPich/CheckMyCrate/blob/master/CheckMyCrate/profile_library/ro_crate_1.1_basic.json">https://github.com/KockataEPich/CheckMyCrate/blob/master/CheckMyCrate/profile_library/ro_crate_1.1_basic.json</a></td>
-            </tr><tr>
-            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
-            <td style='text-align:left'><span>CheckMyCrate profile for Workflow RO-Crate</span></td>
-            </tr><tr>
-            <th style="text-align:left;" class="prop">@type</th>
-            <td style='text-align:left'><span>File</span></td>
-            </tr><tr>
-            <th style="text-align:left;" class="prop">encodingFormat<span>&nbsp;</span><a href="http://schema.org/encodingFormat">[?]</a></th>
-            <td style='text-align:left'><ul>
-                        <li><span>application/json</span></li>
-                        
-                        <li><a href="#https%3A//github.com/KockataEPich/CheckMyCrate%23profiles">CheckMyCrate</a></li>
-                        </ul></td>
-            </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
-            <th style="text-align:left;" class="prop">mentions<span>&nbsp;</span><a href="http://schema.org/mentions">[?]</a></th>
-            <td style='text-align:left'><a href="#./">Workflow RO-Crate profile</a></td>
-            </tr></tbody>
-            </table>
-        </div>
-            </div>
-        <hr/><br/><br/>
-            <div>
-                <h3><a href="https://github.com/crs4/rocrate-validator/tree/develop/rocrate_validator/profiles/workflow-ro-crate/">Go to: </a> rocrate-validator profile for Workflow RO-Crate 1.0</h3>
-                
-                
-                
-                
-        <div id="https://github.com/crs4/rocrate-validator/tree/develop/rocrate_validator/profiles/workflow-ro-crate/">
-            
-            <table class="table metadata table-striped" >
-                <tbody><tr>
-            <th style="text-align:left;" class="prop">@id</th>
-            <td style='text-align:left'><a href="https://github.com/crs4/rocrate-validator/tree/develop/rocrate_validator/profiles/workflow-ro-crate/">https://github.com/crs4/rocrate-validator/tree/develop/rocrate_validator/profiles/workflow-ro-crate/</a></td>
-            </tr><tr>
-            <th style="text-align:left;" class="prop">name<span>&nbsp;</span><a href="http://schema.org/name">[?]</a></th>
-            <td style='text-align:left'><span>rocrate-validator profile for Workflow RO-Crate 1.0</span></td>
-            </tr><tr>
-            <th style="text-align:left;" class="prop">@type</th>
-            <td style='text-align:left'><span>Dataset</span></td>
             </tr><tr><th colspan="2" style="text-align:center">Items that reference this one</th><tr><tr>
             <th style="text-align:left;" class="prop">mentions<span>&nbsp;</span><a href="http://schema.org/mentions">[?]</a></th>
             <td style='text-align:left'><a href="#./">Workflow RO-Crate profile</a></td>

--- a/Workflow-RO-Crate/1.1-DRAFT/ro-crate-preview.html
+++ b/Workflow-RO-Crate/1.1-DRAFT/ro-crate-preview.html
@@ -54,6 +54,7 @@
       ],
       "datePublished": "2023-03-13T10:43:00Z",
       "description": "This is the Profile Crate for Workflow RO-Crate. Workflow RO-Crates are a specialization of RO-Crate for packaging an executable workflow with all necessary documentation. It is aligned with, and intends to strictly extend, the more general Bioschemas ComputationalWorkflow profile.\n\nWorkflowHub uses Workflow RO-Crates as an exchange format for users to upload a packaged workflow.",
+      "keywords": "workflow",
       "hasPart": [
         {
           "@id": "index.html"
@@ -1520,6 +1521,9 @@ WorkflowHub uses Workflow RO-Crates as an exchange format for users to upload a 
                         
                         <li><a href="#https%3A//orcid.org/0000-0001-9842-9718">Stian Soiland-Reyes</a></li>
                         </ul></td>
+            </tr><tr>
+            <th style="text-align:left;" class="prop">keywords<span>&nbsp;</span><a href="http://schema.org/keywords">[?]</a></th>
+            <td style='text-align:left'><span>workflow</span></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">hasPart<span>&nbsp;</span><a href="http://schema.org/hasPart">[?]</a></th>
             <td style='text-align:left'><ul>


### PR DESCRIPTION
* Add profile keywords (useful for profile registry) 
* constrain compatibility to RO-Crate 1.2 only, due to the use of `input` and `output` whose IRIs were changed in 1.2 (see https://github.com/ResearchObject/workflow-run-crate/pull/101#issuecomment-3723545761 for more details)
* add backward compatibility notes to aid implementers who want to support multiple versions of the profile