### PR TITLE
Workflow RO-Crate 1.1-DRAFT: Workflow in example in index.md must have type ComputationalWorkflow

### DIFF
--- a/Workflow-RO-Crate/1.1-DRAFT/index.md
+++ b/Workflow-RO-Crate/1.1-DRAFT/index.md
@@ -14,7 +14,7 @@ title: Workflow RO-Crate profile 1.1-DRAFT
 <link href="https://orcid.org/0000-0002-0048-3300" rel="author"  />
 <link href="https://orcid.org/0000-0003-3156-2105" rel="author"  />
 <link href="https://orcid.org/0000-0003-2130-0865" rel="author"  />
-<link href="https://orcid.org/0000-0003-2130-0865" rel="author"  />
+<link href="https://orcid.org/0000-0001-9842-9718" rel="author"  />
 
 <link href="ro-crate-metadata.json" rel="describedby" type='application/ld+json; profile="https://w3id.org/ro/crate"' />
 <link href="ro-crate-metadata.jsonld" rel="describedby" type='application/ld+json; profile="https://w3id.org/ro/crate"'  />
@@ -43,7 +43,7 @@ title: Workflow RO-Crate profile 1.1-DRAFT
   - Finn Bacall <https://orcid.org/0000-0002-0048-3300>
   - Alan R Williams <https://orcid.org/0000-0003-3156-2105>
   - Stuart Owen <https://orcid.org/0000-0003-2130-0865>
-  - Stian Soiland-Reyes <https://orcid.org/0000-0003-2130-0865>
+  - Stian Soiland-Reyes <https://orcid.org/0000-0001-9842-9718>
 * Title: Workflow RO-Crate profile 1.1-DRAFT
 * Publisher: [WorkflowHub community](https://w3id.org/workflowhub/)
 * Permalink: <https://w3id.org/workflowhub/workflow-ro-crate/1.1-DRAFT> (this version)  

--- a/Workflow-RO-Crate/1.1-DRAFT/index.md
+++ b/Workflow-RO-Crate/1.1-DRAFT/index.md
@@ -373,7 +373,7 @@ A minimal example of _Workflow RO-Crate_ metadata, containing a CWL workflow, an
       "@type": [
         "File",
         "SoftwareSourceCode",
-        "HowTo"
+        "ComputationalWorkflow"
       ],
       "programmingLanguage": {
         "@id": "https://w3id.org/workflowhub/workflow-ro-crate#cwl"


### PR DESCRIPTION
When I set up 1.1-DRAFT I inadvertently copied a slightly out of date version of 1.0 (I guess I forgot to run `git pull` beforehand). This PR re-applies more recent changes; fortunately they are small.

Fixes #55 (which is an earlier duplicate of #75, but it's a good thing #55 didn't get closed because it's what made me spot this!)